### PR TITLE
feat: add custom props to custom unavailability items

### DIFF
--- a/documentation/docs/guides/unavailable-time.mdx
+++ b/documentation/docs/guides/unavailable-time.mdx
@@ -1,3 +1,6 @@
+---
+sidebar_position: 8
+---
 
 import UnavailableAllDays from './img/unavailable-all-days.png';
 import UnavailableWeekDay from './img/unavailable-week-day.png';

--- a/documentation/docs/guides/unavailable-time.mdx
+++ b/documentation/docs/guides/unavailable-time.mdx
@@ -1,6 +1,3 @@
----
-sidebar_position: 8
----
 
 import UnavailableAllDays from './img/unavailable-all-days.png';
 import UnavailableWeekDay from './img/unavailable-week-day.png';
@@ -183,3 +180,75 @@ const _renderCustomUnavailableItem = useCallback(
 ```
 
 <img src={CustomItem} style={{ maxWidth: '320px' }} />
+
+When using a `renderCustomUnavailableItem` you can also send additional information through the `unavailableHours` prop along with the `start` and `end` values. This is useful, for example, for setting a different style or extra info per Unavailable item.
+
+```jsx title="Example"
+
+// Sending "color" as extra prop
+const unavailableHours = [
+  { start: 0, end: 7, color: 'red'},
+  { start: 18, end: 24, color: 'blue' },
+];
+
+const _renderCustomUnavailableItem = useCallback(
+  (props: UnavailableItemProps) => <CustomUnavailableItem {...props} />,
+  []
+);
+
+<TimelineCalendar
+  viewMode="week"
+  unavailableHours={unavailableHours}
+  renderCustomUnavailableItem={_renderCustomUnavailableItem}
+/>;
+```
+
+```jsx title="CustomUnavailableItem.tsx"
+import type { UnavailableItemProps } from '@howljs/calendar-kit';
+import React from 'react';
+import Animated, { useAnimatedProps } from 'react-native-reanimated';
+import Svg, { Defs, Line, Pattern, Rect } from 'react-native-svg';
+
+const AnimatedRect = Animated.createAnimatedComponent(Rect);
+
+const CustomUnavailableItem = (props: UnavailableItemProps) => {
+  const patternSize = 5;
+
+  const rectProps = useAnimatedProps(() => ({
+    height: props.hour * props.timeIntervalHeight.value,
+  }));
+
+  return (
+    <Svg>
+      <Defs>
+        <Pattern
+          id="stripe-pattern"
+          patternUnits="userSpaceOnUse"
+          width={patternSize}
+          height={patternSize}
+          patternTransform="rotate(-45)"
+        >
+          <Line
+            x1={0}
+            y={0}
+            x2={0}
+            y2={patternSize + 5}
+            stroke={props.color} // uses the props sent from the unavailableHours
+            strokeWidth={1.5}
+            strokeLinecap="butt"
+          />
+        </Pattern>
+      </Defs>
+      <AnimatedRect
+        x="0"
+        y="0"
+        width="100%"
+        fill="url(#stripe-pattern)"
+        animatedProps={rectProps}
+      />
+    </Svg>
+  );
+};
+
+export default CustomUnavailableItem;
+```

--- a/src/components/Timeline/TimelineBoard/VerticalBlock.tsx
+++ b/src/components/Timeline/TimelineBoard/VerticalBlock.tsx
@@ -29,7 +29,11 @@ const VerticalBlock: React.FC<VerticalBlockProps> = ({
         key={`${dayIndex}_${i}`}
         top={startFixed - start}
         hour={endFixed - startFixed}
-        renderCustomUnavailableItem={renderCustomUnavailableItem}
+        renderCustomUnavailableItem={
+          renderCustomUnavailableItem
+            ? (props) => renderCustomUnavailableItem({ ...props, ...hour })
+            : undefined
+        }
       />
     );
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,14 +111,11 @@ export interface TimelineProps {
   onTimeIntervalHeightChange?: (height: number) => void;
 }
 
-export interface UnavailableItemProps {
+export type UnavailableItemProps = {
   timeIntervalHeight: SharedValue<number>;
-  start?: number;
-  end?: number;
   hour?: number;
   width?: number;
-  color?: string;
-}
+} & Partial<UnavailableHour>;
 
 export type CalendarViewMode = 'day' | 'week' | 'threeDays' | 'workWeek';
 
@@ -397,6 +394,7 @@ export interface RangeTime {
 export interface UnavailableHour {
   start: number;
   end: number;
+  [key: string]: any;
 }
 
 export type UnavailableHoursStyle = Record<

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,6 @@ export interface TimelineCalendarHandle {
    */
   zoom: (props?: { scale?: number; height?: number }) => void;
 }
-
 export interface TimelineCalendarProps
   extends TimelineProps,
     TimelineProviderProps {}
@@ -113,9 +112,12 @@ export interface TimelineProps {
 }
 
 export interface UnavailableItemProps {
+  start: number;
+  end: number;
   timeIntervalHeight: SharedValue<number>;
   hour: number;
   width: number;
+  color: string;
 }
 
 export type CalendarViewMode = 'day' | 'week' | 'threeDays' | 'workWeek';

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,12 +112,12 @@ export interface TimelineProps {
 }
 
 export interface UnavailableItemProps {
-  start: number;
-  end: number;
   timeIntervalHeight: SharedValue<number>;
-  hour: number;
-  width: number;
-  color: string;
+  start?: number;
+  end?: number;
+  hour?: number;
+  width?: number;
+  color?: string;
 }
 
 export type CalendarViewMode = 'day' | 'week' | 'threeDays' | 'workWeek';


### PR DESCRIPTION
## 🔁 Changes
* Added the ability of forwarding the content of the `unavailableHours` to the `renderCustomUnavailableItem` function as a prop.

## 📝 Other notes
This change should allow us to remove the `.patch` file and give a bit of better type autocompletion.